### PR TITLE
Set buffer size in DownloadFile() to 8192KB from 10KB

### DIFF
--- a/Office-ProPlus-Deployment/Download-OfficeProPlusBranch/Download-OfficeProPlusBranch.ps1
+++ b/Office-ProPlus-Deployment/Download-OfficeProPlusBranch/Download-OfficeProPlusBranch.ps1
@@ -289,7 +289,7 @@ function DownloadFile($url, $targetFile) {
 
    $targetStream = New-Object -TypeName System.IO.FileStream -ArgumentList $targetFile, Create
 
-   $buffer = new-object byte[] 10KB
+   $buffer = new-object byte[] 8192KB
 
    $count = $responseStream.Read($buffer,0,$buffer.length)
 


### PR DESCRIPTION
I found the downloads proceeding extremely slowly (~100-150 KBps) with the buffer size set to 10KB. I increased it 8192 and my speeds increased to around ~10-15 MBps.