### PR TITLE
Azure VM with O365 Pre-installed #devops

### DIFF
--- a/Office-ProPlus-Deployment/Deploy-OfficeClickToRun/10-ExampleDeploySilentWithVersion.ps1
+++ b/Office-ProPlus-Deployment/Deploy-OfficeClickToRun/10-ExampleDeploySilentWithVersion.ps1
@@ -1,0 +1,33 @@
+#  Office ProPlus Click-To-Run Deployment Script example
+#
+#  This script demonstrates how utilize the scripts in OfficeDev/Office-IT-Pro-Deployment-Scripts repository together to create
+#  Office ProPlus Click-To-Run deployment script that will be adaptive to the configuration of the computer it is run from
+
+param([Parameter(Mandatory=$false)][string]$OfficeVersion = "Office2016")
+
+Process {
+ $scriptPath = "."
+
+ if ($PSScriptRoot) {
+   $scriptPath = $PSScriptRoot
+ } else {
+   $scriptPath = split-path -parent $MyInvocation.MyCommand.Definition
+ }
+
+#Importing all required functions
+. $scriptPath\Generate-ODTConfigurationXML.ps1
+. $scriptPath\Edit-OfficeConfigurationFile.ps1
+. $scriptPath\Install-OfficeClickToRun.ps1
+
+$targetFilePath = "$env:temp\configuration.xml"
+
+#This example will create an Office Deployment Tool (ODT) configuration file and include all of the Languages currently in use on the computer
+#from which the script is run.  It will then remove the Version attribute from the XML to ensure the installation gets the latest version
+#when updating an existing install and then it will initiate a install
+
+#This script additionally sets the "AcceptEULA" to "True" and the display "Level" to "None" so the install is silent.
+
+Generate-ODTConfigurationXml -Languages AllInUseLanguages -TargetFilePath $targetFilePath | Set-ODTAdd -Version 15.1.2.3 | Set-ODTDisplay -AcceptEULA $true -Level None | Install-OfficeClickToRun -OfficeVersion $OfficeVersion
+
+# Configuration.xml file for Click-to-Run for Office 365 products reference. https://technet.microsoft.com/en-us/library/JJ219426.aspx
+}

--- a/Office-ProPlus-Deployment/Deploy-OfficeClickToRun/10-ExampleDeploySilentWithVersion.ps1
+++ b/Office-ProPlus-Deployment/Deploy-OfficeClickToRun/10-ExampleDeploySilentWithVersion.ps1
@@ -27,7 +27,7 @@ $targetFilePath = "$env:temp\configuration.xml"
 
 #This script additionally sets the "AcceptEULA" to "True" and the display "Level" to "None" so the install is silent.
 
-Generate-ODTConfigurationXml -Languages AllInUseLanguages -TargetFilePath $targetFilePath | Set-ODTAdd -Version 15.1.2.3 | Set-ODTDisplay -AcceptEULA $true -Level None | Install-OfficeClickToRun -OfficeVersion $OfficeVersion
+Generate-ODTConfigurationXml -Languages AllInUseLanguages -TargetFilePath $targetFilePath | Set-ODTAdd -Version $NULL | Set-ODTDisplay -AcceptEULA $true -Level None | Install-OfficeClickToRun -OfficeVersion $OfficeVersion
 
 # Configuration.xml file for Click-to-Run for Office 365 products reference. https://technet.microsoft.com/en-us/library/JJ219426.aspx
 }

--- a/Office-ProPlus-Deployment/Deploy-OfficeClickToRun/CreateO365AzureVM.ps1
+++ b/Office-ProPlus-Deployment/Deploy-OfficeClickToRun/CreateO365AzureVM.ps1
@@ -1,0 +1,25 @@
+﻿cls
+$RGName = "RG-o365-W10"; 
+$VMName = "jdwino365";
+$VMUsername = "jmd";
+
+$ARMTemplate = "C:\Dump\O365 Testing\azuredeploy.json"
+$DeployLocation = "West Europe"
+$OfficeVersion  = "Office2013"; #or Office2016
+
+# 1. Login
+#Login-AzureRmAccount
+
+#2. Create a resource group
+New-AzureRmResourceGroup -Name $RGName -Location $DeployLocation -Force
+
+#3. Create resources
+$sw = [system.diagnostics.stopwatch]::startNew()
+New-AzureRmResourceGroupDeployment -ResourceGroupName $RGName -TemplateFile $ARMTemplate -vmName $VMName `
+    -vmAdminUserName $VMUsername -dnsLabelPrefix $VMName -vmVisualStudioVersion VS-2015-Comm-AzureSDK-2.9-W10T-Win10-N `
+    -officeVersion "Office2013" -Mode Complete -Force | Out-Null
+$sw | Format-List -Property *
+
+#4. Get the RDP file
+Get-AzureRmRemoteDesktopFile -ResourceGroupName $RGName -Name $VMName -Launch -Verbose -Debug
+

--- a/Office-ProPlus-Deployment/Deploy-OfficeClickToRun/azuredeploy.json
+++ b/Office-ProPlus-Deployment/Deploy-OfficeClickToRun/azuredeploy.json
@@ -1,0 +1,272 @@
+{
+  "$schema": "http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+  "contentVersion": "1.0.0.1",
+  "parameters": {
+      "storageType": {
+      "type": "string",
+      "defaultValue": "Premium_LRS",
+      "allowedValues": [
+        "Premium_LRS",
+        "Standard_LRS"
+      ],
+      "metadata": {
+        "description": "Which type of storage you want to use"
+      }
+    },
+    "vmName": {
+      "type": "string",
+      "metadata": {
+        "description": "Local name for the VM can be whatever you want"
+      }
+    },
+    "vmAdminUserName": {
+      "type": "string",
+      "metadata": {
+        "description": "VM admin user name"
+      }
+    },
+    "vmAdminPassword": {
+      "type": "securestring",
+      "metadata": {
+        "description": "VM admin password. The supplied password must be between 8-123 characters long and must satisfy at least 3 of password complexity requirements from the following: 1) Contains an uppercase character 2) Contains a lowercase character 3) Contains a numeric digit 4) Contains a special character."
+      }
+    },
+    "vmSize": {
+      "type": "string",
+      "metadata": {
+        "description": "Desired Size of the VM. Any valid option accepted but if you choose premium storage type you must choose a DS class VM size."
+      },
+      "defaultValue": "Standard_DS2"
+    },
+    "vmVisualStudioVersion": {
+      "type": "string",
+      "defaultValue": "VS-2015-Ent-VSU2-AzureSDK-29-W10T-N-x64",
+      "allowedValues": [
+        "VS-2015-Comm-AzureSDK-2.9-W10T-Win10-N",
+        "VS-2015-Comm-AzureSDK-2.9-WS2012R2",
+        "VS-2015-Comm-VSU1-AzureSDK-2.8-W10T-N-x64",
+        "VS-2015-Comm-VSU2-AzureSDK-29-W10T-N-x64",
+        "VS-2015-Comm-VSU2-AzureSDK-29-WS2012R2",
+        "VS-2015-Community-AzureSDK-2.7-Cordova-Win8.1-N-x64",
+        "VS-2015-Community-AzureSDK-2.7-W10T-Win10-N",
+        "VS-2015-Community-AzureSDK-2.7-WS2012R2",
+        "VS-2015-Ent-AzureSDK-2.8-Cordova-Win8.1-N-x64",
+        "VS-2015-Ent-AzureSDK-29-W10T-Win10-N",
+        "VS-2015-Ent-VSU2-AzureSDK-29-W10T-N-x64",
+        "VS-2015-Ent-VSU2-AzureSDK-29-WS2012R2",
+        "VS-2015-Enterprise-AzureSDK-2.7-Cordova-Win8.1-N-x64",
+        "VS-2015-Enterprise-AzureSDK-2.7-W10T-Win10-N",
+        "VS-2015-Enterprise-AzureSDK-2.7-WS2012R2",
+        "VS-2015-Pro-AzureSDK-2.8-Cordova-Win8.1-N-x64",
+        "VS-2015-Professional-AzureSDK-2.7-Cordova-Win8.1-N-x64",
+        "VS-2015-Professional-AzureSDK-2.7-W10T-Win10-N"
+      ],
+      "metadata": {
+        "description": "Which version of Visual Studio you would like to deploy"
+      }
+    },
+    "dnsLabelPrefix": {
+      "type": "string",
+      "metadata": {
+      "description": "DNS Label for the Public IP. Must be lowercase. It should match with the following regular expression: ^[a-z][a-z0-9-]{1,61}[a-z0-9]$ or it will raise an error."
+      }
+    },
+    "officeVersion": {
+      "type": "string",
+      "defaultValue": "Office2016",
+      "allowedValues": [
+        "Office2016",
+        "Office2013"
+      ],
+       "metadata": {
+        "description": "Which version of Office would you would like to deploy"
+      }
+    },    
+    "setupOfficeScriptFileName": {
+      "type": "string",
+      "defaultValue": "10-ExampleDeploySilentWithVersion.ps1",
+      "metadata": {
+        "description": "PowerShell script name to execute"
+      }
+    }
+  },
+    "variables": {
+      "storageName": "[concat(uniquestring(resourceGroup().id), 'standardsa')]",
+      "vnet01Prefix": "10.0.0.0/16",
+      "vnet01Subnet1Name": "Subnet-1",
+      "vnet01Subnet1Prefix": "10.0.0.0/24",
+      "vmImagePublisher": "MicrosoftVisualStudio",
+      "vmImageOffer": "VisualStudio",
+      "vmOSDiskName": "VMOSDisk",
+      "vmVnetID": "[resourceId('Microsoft.Network/virtualNetworks', 'Vnet01')]",
+      "vmSubnetRef": "[concat(variables('VMVnetID'), '/subnets/', variables('Vnet01Subnet1Name'))]",
+      "vmStorageAccountContainerName": "vhds",
+      "vmNicName": "[concat(parameters('VMName'), 'NetworkInterface')]",
+      "vmIP01Name": "VMIP01"
+    },
+    "resources": [
+      {
+        "name": "[variables('storageName')]",
+        "type": "Microsoft.Storage/storageAccounts",
+        "location": "[resourceGroup().location]",
+        "apiVersion": "2015-06-15",
+        "dependsOn": [ ],
+        "tags": {
+          "displayName": "Storage01"
+        },
+        "properties": {
+          "accountType": "[parameters('storageType')]"
+        }
+      },
+      {
+        "name": "VNet01",
+        "type": "Microsoft.Network/virtualNetworks",
+        "location": "[resourceGroup().location]",
+        "apiVersion": "2015-06-15",
+        "dependsOn": [ ],
+        "tags": {
+          "displayName": "VNet01"
+        },
+        "properties": {
+          "addressSpace": {
+            "addressPrefixes": [
+              "[variables('vnet01Prefix')]"
+            ]
+          },
+          "subnets": [
+            {
+              "name": "[variables('vnet01Subnet1Name')]",
+              "properties": {
+                "addressPrefix": "[variables('vnet01Subnet1Prefix')]"
+              }
+            }
+          ]
+        }
+      },
+      {
+        "name": "[variables('vmNicName')]",
+        "type": "Microsoft.Network/networkInterfaces",
+        "location": "[resourceGroup().location]",
+        "apiVersion": "2015-06-15",
+        "dependsOn": [
+          "[concat('Microsoft.Network/virtualNetworks/', 'Vnet01')]",
+          "[concat('Microsoft.Network/publicIPAddresses/', variables('vmIP01Name'))]"
+        ],
+        "tags": {
+          "displayName": "VMNic01"
+        },
+        "properties": {
+          "ipConfigurations": [
+            {
+              "name": "ipconfig1",
+              "properties": {
+                "privateIPAllocationMethod": "Dynamic",
+                "subnet": {
+                  "id": "[variables('vmSubnetRef')]"
+                },
+                "publicIPAddress": {
+                  "id": "[resourceId('Microsoft.Network/publicIPAddresses', variables('vmIP01Name'))]"
+                }
+              }
+            }
+          ]
+        }
+      },
+      {
+        "name": "[parameters('vmName')]",
+        "type": "Microsoft.Compute/virtualMachines",
+        "location": "[resourceGroup().location]",
+        "apiVersion": "2015-06-15",
+        "dependsOn": [
+          "[concat('Microsoft.Storage/storageAccounts/', variables('storageName'))]",
+          "[concat('Microsoft.Network/networkInterfaces/', variables('vmNicName'))]"
+        ],
+        "tags": {
+          "displayName": "VM01"
+        },
+        "properties": {
+          "hardwareProfile": {
+            "vmSize": "[parameters('vmSize')]"
+          },
+          "osProfile": {
+            "computername": "[parameters('vmName')]",
+            "adminUsername": "[parameters('vmAdminUsername')]",
+            "adminPassword": "[parameters('vmAdminPassword')]"
+          },
+          "storageProfile": {
+            "imageReference": {
+              "publisher": "[variables('vmImagePublisher')]",
+              "offer": "[variables('vmImageOffer')]",
+              "sku": "[parameters('vmVisualStudioVersion')]",
+              "version": "latest"
+            },
+            "osDisk": {
+              "name": "VMOSDisk",
+              "vhd": {
+                "uri": "[concat('http://', variables('storageName'), '.blob.core.windows.net/', variables('vmStorageAccountContainerName'), '/', variables('vmOSDiskName'), '.vhd')]"
+              },
+              "caching": "ReadWrite",
+              "createOption": "FromImage"
+            }
+          },
+          "networkProfile": {
+            "networkInterfaces": [
+              {
+                "id": "[resourceId('Microsoft.Network/networkInterfaces', variables('vmNicName'))]"
+              }
+            ]
+          }
+        },
+        "resources": [
+          {
+            "name": "SetupOffice",
+            "type": "extensions",
+            "location": "[resourceGroup().location]",
+            "apiVersion": "2015-06-15",
+            "dependsOn": [
+              "[concat('Microsoft.Compute/virtualMachines/', parameters('vmName'))]"
+            ],
+            "tags": {
+              "displayName": "SetupOffice"
+            },
+            "properties": {
+              "publisher": "Microsoft.Compute",
+              "type": "CustomScriptExtension",
+              "typeHandlerVersion": "1.4",
+              "autoUpgradeMinorVersion": true,
+              "settings": {
+                "fileUris": [
+                  "[concat('https://raw.githubusercontent.com/daltskin/Office-IT-Pro-Deployment-Scripts/master/Office-ProPlus-Deployment/Deploy-OfficeClickToRun/', parameters('setupOfficeScriptFileName'))]",
+                  "https://raw.githubusercontent.com/daltskin/Office-IT-Pro-Deployment-Scripts/master/Office-ProPlus-Deployment/Deploy-OfficeClickToRun/DefaultConfiguration.xml",
+                  "https://raw.githubusercontent.com/daltskin/Office-IT-Pro-Deployment-Scripts/master/Office-ProPlus-Deployment/Deploy-OfficeClickToRun/Office2013Setup.exe",
+                  "https://raw.githubusercontent.com/daltskin/Office-IT-Pro-Deployment-Scripts/master/Office-ProPlus-Deployment/Deploy-OfficeClickToRun/Office2016Setup.exe",
+                  "https://raw.githubusercontent.com/daltskin/Office-IT-Pro-Deployment-Scripts/master/Office-ProPlus-Deployment/Deploy-OfficeClickToRun/Edit-OfficeConfigurationFile.ps1",
+                  "https://raw.githubusercontent.com/daltskin/Office-IT-Pro-Deployment-Scripts/master/Office-ProPlus-Deployment/Deploy-OfficeClickToRun/Generate-ODTConfigurationXML.ps1",
+                  "https://raw.githubusercontent.com/daltskin/Office-IT-Pro-Deployment-Scripts/master/Office-ProPlus-Deployment/Deploy-OfficeClickToRun/Install-OfficeClickToRun.ps1"
+                ],
+                "commandToExecute": "[concat('powershell -ExecutionPolicy bypass -File ', parameters('setupOfficeScriptFileName'),' -OfficeVersion ', parameters('officeVersion'))]"
+              }
+            }
+          }
+        ]
+      },
+      {
+        "name": "[variables('vmIP01Name')]",
+        "type": "Microsoft.Network/publicIPAddresses",
+        "location": "[resourceGroup().location]",
+        "apiVersion": "2015-06-15",
+        "dependsOn": [ ],
+        "tags": {
+          "displayName": "VMIP01"
+        },
+        "properties": {
+          "publicIPAllocationMethod": "Dynamic",
+          "dnsSettings": {
+            "domainNameLabel": "[parameters('dnsLabelPrefix')]"
+          }
+        }
+      }
+    ],
+    "outputs": { }
+  }
+


### PR DESCRIPTION
New ARM template to provision a new Azure VM with either Office 2013 or Office 2016 pre-installed to assist with development and testing of O365 Addins.

Script included to provision a new Azure VM with Office and then download the RDP file.  Provisioning takes anywhere between 8-20 mins (dependent on Azure) to create a brand new VM with Office version pre-installed (using silent installation).

ARM template requires reference to new powershell script, currently in my fork.  This will need to be updated once in the master branch - which I can patch once accepted.