### PR TITLE
Changing to output integer rather than "TRUE"/"FALSE"

### DIFF
--- a/Office-ProPlus-Deployment/Edit-OfficeConfigurationFile/Edit-OfficeConfigurationFile.ps1
+++ b/Office-ProPlus-Deployment/Edit-OfficeConfigurationFile/Edit-OfficeConfigurationFile.ps1
@@ -2092,7 +2092,7 @@ Here is what the portion of configuration file looks like when modified by this 
                 
             $ConfigFile.Configuration.appendChild($SharedComputerLicensingElement) | Out-Null
             $SharedComputerLicensingElement.SetAttribute("Name", "SharedComputerLicensing") | Out-Null
-            $SharedComputerLicensingElement.SetAttribute("Value", $SharedComputerLicensing.ToString().ToUpper()) | Out-Null
+            $SharedComputerLicensingElement.SetAttribute("Value", [int]$SharedComputerLicensing) | Out-Null
             WriteToLogFile -LNumber $(LINENUM) -FName $currentFileName -ActionError "Setting the SharedComputerLicensing element to $SharedComputerLicensing.ToString().ToUpper()" -LogFilePath $LogFilePath
         } Else {
             [System.XML.XMLElement]$SharedComputerLicensingElement = $ConfigFile.Configuration.Property | Where { $_.Name -eq "SharedComputerLicensing" }


### PR DESCRIPTION
Changing due to error resulting from use of script as-is, did not install properly on Server 2016 servers and is not in line with documentation. Please see issue of same file for more info.