### PR TITLE
Remove extra 's' from InsiderSlow

### DIFF
--- a/Office-ProPlus-Deployment/Download-OfficeProPlusBranch/Download-OfficeProPlusChannels.ps1
+++ b/Office-ProPlus-Deployment/Download-OfficeProPlusBranch/Download-OfficeProPlusChannels.ps1
@@ -745,7 +745,7 @@ function GetVersionBasedOnThrottle {
 
         $versionToReturn
         $checkChannel = $Channel
-        if($checkChannel -like "FirstReleaseCurrent"){$checkChannel = "InsidersSlow"}
+        if($checkChannel -like "FirstReleaseCurrent"){$checkChannel = "InsiderSlow"}
 
         $historyOfVersionsLink = "http://officecdn.microsoft.com/pr/wsus/releasehistory.cab"
 


### PR DESCRIPTION
Downloading only the FirstReleaseCurrent version was failing with a "Cannot index into a null array".  The script was looking for InsidersSlow instead of InsiderSlow.  