### PR TITLE
UseBasicParsing for Invoke-WebRequest

### DIFF
--- a/Office-ProPlus-Deployment/Download-OfficeProPlusBranch/Download-OfficeProPlusChannels.ps1
+++ b/Office-ProPlus-Deployment/Download-OfficeProPlusBranch/Download-OfficeProPlusChannels.ps1
@@ -328,7 +328,7 @@ For($i=1; $i -le $NumOfRetries; $i++){#loops through download process in the eve
                     $url = "$baseURL$relativePath$fileName"
 
                     try {
-                        Invoke-WebRequest -Uri $url -ErrorAction Stop | Out-Null
+                        Invoke-WebRequest -Uri $url -UseBasicParsing -ErrorAction Stop | Out-Null
                     } catch {
                       Write-Host "`t`tVersion Not Found: $currentVersion"
                       WriteToLogFile -LNumber $(LINENUM) -FName $currentFileName -ActionError "Version Not Found: $currentVersion" -LogFilePath $LogFilePath


### PR DESCRIPTION
When the script is run with a service account that hasn't run IE the Invoke-WebRequest command was throwing an error.  I looks like the command is just being used verify internet connectivity.  Adding UseBasicParsing will allow the test without requiring IE to be setup or IE at all.