### PR TITLE
Add notice per #323 - No longer being maintained

### DIFF
--- a/XmlEditor.html
+++ b/XmlEditor.html
@@ -1333,13 +1333,20 @@
                     <div id="disclaimer">
                         <p class="ms-font-l ms-fontWeight-semibold">
                             <img src="images/Warning64.png" alt="Warning" />
-                            ALERT: New Version of the Office Deployment Tool (ODT)
+                            ALERT: This tool is no longer being maintained
+                        <p class="ms-font-m">
+							The <i>Office Click-To-Run Configuration XML Editor</i> is no longer being maintained and will soon be replaced by the <a style="cursor:pointer" onclick="OpenInNewTab('https://config.office.com/')">Office Customization Tool</a>. 
+                        </p>
+                        </p>
+                        <hr />							
+                        <p class="ms-font-l ms-fontWeight-semibold">
+                            Warning about using old versions of the Office Deployment Tool (ODT)							
                         <p class="ms-font-m">
                             The latest version of the Office Deployment Tool (ODT) now supports using the Channel parameter in the configuration XML. This site will now use
-                            the Channel parameter instead of Branch. Previous versions of the Office Deployment Tool (ODT) will not recognize the Channel parameter and will
+                            the Channel parameter instead of Branch. Some previous versions of the Office Deployment Tool (ODT) will not recognize the Channel parameter and will
                             ignore it and default to Deferred channel. To avoid this issue you must download and use the latest version of ODT.
                             <br /><br />
-                            <a style="cursor:pointer" onclick="OpenInNewTab('https://www.microsoft.com/en-us/download/details.aspx?id=49117')">Office Deployment Tool (2016)</a>
+                            <a style="cursor:pointer" onclick="OpenInNewTab('https://www.microsoft.com/en-us/download/details.aspx?id=49117')">Click here to download the latest Office Deployment Tool</a>
                         </p>
                         </p>
                         <hr />


### PR DESCRIPTION
It reads: "The Office Click-To-Run Configuration XML Editor is no longer being maintained and will soon be replaced by the Office Customization Tool."