### PR TITLE
Support PowerShell v2 (Windows 7)

### DIFF
--- a/Office-ProPlus-Deployment/Remove-PreviousOfficeInstalls/Remove-PreviousOfficeInstalls.ps1
+++ b/Office-ProPlus-Deployment/Remove-PreviousOfficeInstalls/Remove-PreviousOfficeInstalls.ps1
@@ -1314,17 +1314,22 @@ Function IsDotSourced() {
 }
 
 Function GetScriptRoot() {
- process {
-     [string]$scriptPath = "."
+    process {
+        [string]$scriptPath = "."
+        if ($PSScriptRoot -or $MyInvocation.ScriptName) {
+            if ($MyInvocation.ScriptName) {
+                $scriptPath = $MyInvocation.ScriptName | Split-Path
+            }
+            if ($PSScriptRoot) {
+                $scriptPath = $PSScriptRoot
+            }
+        }
+        else {
+            $scriptPath = (Get-Item -Path ".\").FullName
+        }
 
-     if ($PSScriptRoot) {
-       $scriptPath = $PSScriptRoot
-     } else {
-       $scriptPath = (Get-Item -Path ".\").FullName
-     }
-
-     return $scriptPath
- }
+        return $scriptPath
+    }
 }
 
 function GetProductName {


### PR DESCRIPTION
This allows the script to support PowerShell v2 as the rest of the script does.

Previously it would fail with some bad path errors.